### PR TITLE
feat: 엔티티 추가

### DIFF
--- a/src/main/java/toock/backend/company/domain/Company.java
+++ b/src/main/java/toock/backend/company/domain/Company.java
@@ -1,0 +1,31 @@
+package toock.backend.company.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Builder
+    public Company(String name, String code) {
+        this.name = name;
+        this.code = code;
+    }
+}
+
+

--- a/src/main/java/toock/backend/company/domain/CompanyReview.java
+++ b/src/main/java/toock/backend/company/domain/CompanyReview.java
@@ -1,0 +1,67 @@
+package toock.backend.company.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Column(length = 50)
+    private String field;
+
+    @Column(length = 50)
+    private String level;
+
+    @Column
+    private OffsetDateTime createdAt;
+
+    @Column
+    private LocalDate interviewedAt;
+
+    @Column(length = 255)
+    private String interviewFormat;
+
+    @Column(length = 50)
+    private String difficulty;
+
+    @Lob
+    @Column
+    private String summary;
+
+    @Builder
+    public CompanyReview(Company company,
+                        String field,
+                        String level,
+                        OffsetDateTime createdAt,
+                        LocalDate interviewedAt,
+                        String interviewFormat,
+                        String difficulty,
+                        String summary) {
+        this.company = company;
+        this.field = field;
+        this.level = level;
+        this.createdAt = createdAt;
+        this.interviewedAt = interviewedAt;
+        this.interviewFormat = interviewFormat;
+        this.difficulty = difficulty;
+        this.summary = summary;
+    }
+}
+
+

--- a/src/main/java/toock/backend/interview/domain/InterviewAnalysis.java
+++ b/src/main/java/toock/backend/interview/domain/InterviewAnalysis.java
@@ -1,0 +1,49 @@
+package toock.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewAnalysis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "interview_id", nullable = false)
+    private InterviewSession interviewSession;
+
+    @Column
+    private Integer score;
+
+    @Column
+    private Integer technicalScore;
+
+    @Column
+    private Integer attitudeScore;
+
+    @Lob
+    @Column
+    private String summary;
+
+    @Builder
+    public InterviewAnalysis(InterviewSession interviewSession,
+                            Integer score,
+                            Integer technicalScore,
+                            Integer attitudeScore,
+                            String summary) {
+        this.interviewSession = interviewSession;
+        this.score = score;
+        this.technicalScore = technicalScore;
+        this.attitudeScore = attitudeScore;
+        this.summary = summary;
+    }
+}
+
+

--- a/src/main/java/toock/backend/interview/domain/InterviewQA.java
+++ b/src/main/java/toock/backend/interview/domain/InterviewQA.java
@@ -1,0 +1,60 @@
+package toock.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "interviewqa",
+       uniqueConstraints = {
+           @UniqueConstraint(name = "uk_interview_question_order",
+                             columnNames = {"interview_id", "question_order"})
+       })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewQA {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "interview_id", nullable = false)
+    private InterviewSession interviewSession;
+
+    @Column(name = "question_order", nullable = false)
+    private Integer questionOrder;
+
+    @Lob
+    @Column(nullable = false)
+    private String questionText;
+
+    @Lob
+    @Column
+    private String answerText;
+
+    @Column
+    private Integer responseTimeSeconds;
+
+    @Column(length = 500)
+    private String s3Url;
+
+    @Builder
+    public InterviewQA(InterviewSession interviewSession,
+                       Integer questionOrder,
+                       String questionText,
+                       String answerText,
+                       Integer responseTimeSeconds,
+                       String s3Url) {
+        this.interviewSession = interviewSession;
+        this.questionOrder = questionOrder;
+        this.questionText = questionText;
+        this.answerText = answerText;
+        this.responseTimeSeconds = responseTimeSeconds;
+        this.s3Url = s3Url;
+    }
+}
+
+

--- a/src/main/java/toock/backend/interview/domain/InterviewSession.java
+++ b/src/main/java/toock/backend/interview/domain/InterviewSession.java
@@ -1,0 +1,60 @@
+package toock.backend.interview.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import toock.backend.company.domain.Company;
+import toock.backend.user.domain.Field;
+import toock.backend.user.domain.Member;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Field field;
+
+    @Column(length = 50)
+    private String status;
+
+    @Column
+    private OffsetDateTime startedAt;
+
+    @Column
+    private OffsetDateTime completedAt;
+
+    @Builder
+    public InterviewSession(Member member,
+                           Company company,
+                           Field field,
+                           String status,
+                           OffsetDateTime startedAt,
+                           OffsetDateTime completedAt) {
+        this.member = member;
+        this.company = company;
+        this.field = field;
+        this.status = status;
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
+    }
+}
+
+

--- a/src/main/java/toock/backend/user/domain/Member.java
+++ b/src/main/java/toock/backend/user/domain/Member.java
@@ -5,9 +5,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
+@Where(clause = "status = 'ACTIVATED'")
+@SQLDelete(sql = "UPDATE member SET status = 'DELETED' WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 


### PR DESCRIPTION
### Desc
- 설계한 대로 엔티티들을 일괄 추가하자
- Member 테이블에 status 컬럼을 기반으로 soft delete 적용
```
Table Member { // 가입한 회원 정보
  id        int           [pk, increment]
  email     varchar(255)  [not null, unique]
  name      varchar(255)  [not null]
  username  varchar(255)  [not null, unique]
  status    enum          [note: 'ACTIVATED', 'DELETED']
  password  varchar(255)  [not null, note: 'secret key로 해싱 필요']
  field     enum          [note: 'BACKEND, FRONTEND, DEVOPS, DATA_SCIENCE, AI, SECURITY']
}

Table Company { // 회사 정보
  id    int           [pk, increment]
  name  varchar(255)  [not null]
  code  varchar(50)   [not null, unique]
}

Table CompanyReview { // 회사 리뷰
  id               int           [pk, increment]
  company_id       int           [not null, ref: > Company.id]
  field            varchar(50)
  level            varchar(50)
  created_at       timestamp
  interviewed_at   date
  interview_format varchar(255)
  difficulty       varchar(50)
  summary          text
}

Table InterviewSession { // 인터뷰 진행 세션
  id           int           [pk, increment]
  member_id    int           [not null, ref: > Member.id]
  company_id   int           [not null, ref: > Company.id]
  field        enum          [note: 'BACKEND, FRONTEND, DEVOPS, DATA_SCIENCE, AI, SECURITY']
  status       varchar(50)
  started_at   timestamp
  completed_at timestamp
}

Table InterviewAnalysis { // 인터뷰 분석 결과
  id               int   [pk, increment]
  interview_id     int   [not null, ref: > InterviewSession.id]
  score            int
  technical_score  int   [note: '추가 평가 지표 컬럼 확장 가능']
  attitude_score   int   [note: '추가 평가 지표 컬럼 확장 가능']
  technical_score  int   [note: '추가 평가 지표 컬럼 확장 가능']
  technical_score  int   [note: '추가 평가 지표 컬럼 확장 가능']
  summary          text
}

Table InterviewQA { // 인터뷰 질문-답변 통합 테이블
  id                     int           [pk, increment]                // QA 고유 ID
  interview_id           int           [not null, ref: > InterviewSession.id]  // 세션 외래키
  question_order         int           [not null]                      // 질문 순서 (동일한 세션id 내에서 auto_increment)
  question_text          text          [not null]                      // 질문 내용
  answer_text            text                                           // 답변 내용(STT 결과)
  response_time_seconds  int                                            // 답변 시간(초)
  s3_url                 varchar(500)                                 // 음성 S3 URL
}
```