### PR TITLE
feat: 음성 파일 번역 서비스 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      # 4. application-dev.yml에 GitHub Secrets 주입 (MySQL 연결 정보)
+      # 4. application-dev.yml에 GitHub Secrets 주입
       - name: Inject secrets into application-dev.yml
         uses: cschleiden/replace-tokens@v1
         with:
@@ -44,6 +44,7 @@ jobs:
           DATASOURCE_URL: ${{ secrets.DATASOURCE_URL }}
           DATASOURCE_USERNAME: ${{ secrets.DATASOURCE_USERNAME }}
           DATASOURCE_PASSWORD: ${{ secrets.DATASOURCE_PASSWORD }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       # 5. Gradle 빌드 (테스트 제외, 캐시 사용)
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // WebClient (HTTP 클라이언트)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // 파일 업로드 처리를 위한 Apache Commons
+    implementation 'commons-io:commons-io:2.15.1'
+
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/toock/backend/global/config/WebClientConfig.java
+++ b/src/main/java/toock/backend/global/config/WebClientConfig.java
@@ -1,0 +1,19 @@
+package toock.backend.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        log.info("WebClient 초기화 완료");
+        return WebClient.builder()
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(50 * 1024 * 1024)) // 50MB
+                .build();
+    }
+}

--- a/src/main/java/toock/backend/whisper/exception/WhisperException.java
+++ b/src/main/java/toock/backend/whisper/exception/WhisperException.java
@@ -1,0 +1,12 @@
+package toock.backend.whisper.exception;
+
+public class WhisperException extends RuntimeException {
+    
+    public WhisperException(String message) {
+        super(message);
+    }
+    
+    public WhisperException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/toock/backend/whisper/service/WhisperService.java
+++ b/src/main/java/toock/backend/whisper/service/WhisperService.java
@@ -1,0 +1,188 @@
+package toock.backend.whisper.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WhisperService {
+
+    private final WebClient webClient;
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${whisper.upload.dir:uploads/audio}")
+    private String uploadDir;
+
+    /**
+     * 음성 파일을 텍스트로 변환
+     * @param audioFile 업로드된 음성 파일
+     * @return 변환된 텍스트
+     */
+    public String transcribeAudio(MultipartFile audioFile) {
+        try {
+            validateAudioFile(audioFile);
+            
+            Path tempFilePath = saveToTempFile(audioFile);
+            
+            try {
+                String transcription = callWhisperApi(tempFilePath, audioFile.getOriginalFilename());
+                log.info("음성 변환 완료: 파일명={}, 변환된 텍스트 길이={}", 
+                    audioFile.getOriginalFilename(), 
+                    transcription.length());
+                return transcription;
+            } finally {
+                Files.deleteIfExists(tempFilePath);
+            }
+            
+        } catch (Exception e) {
+            log.error("음성 변환 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("음성 변환 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * OpenAI Whisper API 호출
+     */
+    private String callWhisperApi(Path audioFilePath, String originalFilename) throws IOException {
+        try {
+            byte[] audioBytes = Files.readAllBytes(audioFilePath);
+            ByteArrayResource audioResource = new ByteArrayResource(audioBytes) {
+                @Override
+                public String getFilename() {
+                    return originalFilename;
+                }
+            };
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", audioResource);
+            body.add("model", "whisper-1");
+
+            String response = webClient.post()
+                    .uri("https://api.openai.com/v1/audio/transcriptions")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + openaiApiKey)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(body))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            // JSON 응답에서 text 필드 추출
+            return extractTextFromResponse(response);
+            
+        } catch (Exception e) {
+            log.error("Whisper API 호출 실패: {}", e.getMessage());
+            throw new RuntimeException("Whisper API 호출 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * API 응답에서 텍스트 추출
+     */
+    private String extractTextFromResponse(String response) {
+        // TODO: Jackson으로 직렬화 하는게 더 좋을듯?
+        if (response != null && response.contains("\"text\"")) {
+            int textStart = response.indexOf("\"text\"") + 8;
+            int textEnd = response.indexOf("\"", textStart);
+            if (textEnd > textStart) {
+                return response.substring(textStart, textEnd);
+            }
+        }
+        throw new RuntimeException("API 응답에서 텍스트를 추출할 수 없습니다.");
+    }
+
+    /**
+     * 음성 파일 유효성 검사
+     */
+    private void validateAudioFile(MultipartFile audioFile) {
+        if (audioFile == null || audioFile.isEmpty()) {
+            throw new IllegalArgumentException("음성 파일이 비어있습니다.");
+        }
+
+        String originalFilename = audioFile.getOriginalFilename();
+        if (originalFilename == null || originalFilename.trim().isEmpty()) {
+            throw new IllegalArgumentException("유효하지 않은 파일명입니다.");
+        }
+
+        String fileExtension = getFileExtension(originalFilename).toLowerCase();
+        if (!isSupportedAudioFormat(fileExtension)) {
+            throw new IllegalArgumentException("지원하지 않는 오디오 형식입니다. 지원 형식: mp3, mp4, mpeg, mpga, m4a, wav, webm");
+        }
+
+        long maxSize = 25 * 1024 * 1024; // 25MB
+        if (audioFile.getSize() > maxSize) {
+            throw new IllegalArgumentException("파일 크기가 너무 큽니다. 최대 25MB까지 지원합니다.");
+        }
+    }
+
+    /**
+     * 임시 파일로 저장
+     */
+    private Path saveToTempFile(MultipartFile audioFile) throws IOException {
+        Path uploadPath = Paths.get(uploadDir);
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+
+        String originalFilename = audioFile.getOriginalFilename();
+        String fileExtension = getFileExtension(originalFilename);
+        String uniqueFilename = generateUniqueFilename(fileExtension);
+        
+        Path filePath = uploadPath.resolve(uniqueFilename);
+        
+        Files.copy(audioFile.getInputStream(), filePath);
+        
+        return filePath;
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf('.');
+        return lastDotIndex > 0 ? filename.substring(lastDotIndex + 1) : "";
+    }
+
+    /**
+     * 지원하는 오디오 형식인지 확인
+     */
+    private boolean isSupportedAudioFormat(String extension) {
+        String[] supportedFormats = {"mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"};
+        for (String format : supportedFormats) {
+            if (format.equals(extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 고유한 파일명 생성
+     */
+    private String generateUniqueFilename(String extension) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        return String.format("audio_%s_%s.%s", timestamp, uuid, extension);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,4 +8,17 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+
+openai:
+  api:
+    key: #{OPENAI_API_KEY}
+    timeout: 60
+
+whisper:
+  upload:
+    dir: uploads/audio
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,3 +8,16 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+
+openai:
+  api:
+    key: ${OPENAI_API_KEY:}
+    timeout: 60
+
+whisper:
+  upload:
+    dir: uploads/audio

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,3 +9,16 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+  servlet:
+    multipart:
+      max-file-size: 25MB
+      max-request-size: 25MB
+
+openai:
+  api:
+    key: test-api-key
+    timeout: 60
+
+whisper:
+  upload:
+    dir: test-uploads/audio

--- a/src/test/java/toock/backend/whisper/service/WhisperServiceTest.java
+++ b/src/test/java/toock/backend/whisper/service/WhisperServiceTest.java
@@ -1,0 +1,68 @@
+package toock.backend.whisper.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class WhisperServiceTest {
+
+    @Mock
+    private WebClient webClient;
+
+    @InjectMocks
+    private WhisperService whisperService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(whisperService, "uploadDir", "test-uploads");
+    }
+
+    @Test
+    void testTranscribeAudio_EmptyFile() {
+        // Given
+        MockMultipartFile emptyFile = new MockMultipartFile(
+            "audioFile",
+            "empty.mp3",
+            "audio/mpeg",
+            new byte[0]
+        );
+
+        // When & Then
+        assertThrows(RuntimeException.class, () -> {
+            whisperService.transcribeAudio(emptyFile);
+        });
+    }
+
+    @Test
+    void testTranscribeAudio_UnsupportedFormat() {
+        // Given
+        MockMultipartFile unsupportedFile = new MockMultipartFile(
+            "audioFile",
+            "test.txt",
+            "text/plain",
+            "test content".getBytes()
+        );
+
+        // When & Then
+        assertThrows(RuntimeException.class, () -> {
+            whisperService.transcribeAudio(unsupportedFile);
+        });
+    }
+
+    @Test
+    void testTranscribeAudio_NullFile() {
+        // When & Then
+        assertThrows(RuntimeException.class, () -> {
+            whisperService.transcribeAudio(null);
+        });
+    }
+}


### PR DESCRIPTION
### Desc
- OpenAI Whisper API를 호출해 업로드 음성을 텍스트로 변환하는 서비스
  - Clova, Google, Whisper중에 고민하다가, 실시간 처리가 아닌 점, 그리고 퍼포먼스 등을 종합 고려하여 Whisper을 사용하고자 합니다
- 파일 유효성 검증을 한 뒤, 서버쪽에 임시 저장. 그 후 Whisper API를 호출하여 응답 텍스트를 반환하며 임시 파일을 정리하는 방식으로 구현
- OpenAI API Key를 발급받아 secret에 추가해야 서버에서 번역이 정상 처리됩니다.
  - 개인적으로 가지고 있는 key가 있어 테스트는 해봤으나, 저희 서비스용 새로운 key 발급이 필요할 것 같습니다