### PR TITLE
feat: 프로젝트 CI Action 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI (Build & Test)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Setup Gradle and cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Verify build
+        run: ./gradlew clean build --no-daemon --stacktrace
+
+


### PR DESCRIPTION
### Desc
- 프로젝트의 안정성을 위한 CI Action 추가
- 빌드와 테스트를 Java 17, Gradle 캐시 포함으로 GitHub Actions에서 실행
- PR을 열거나, push실행시에 action이 트리거