### PR TITLE
feat: S3 음성 파일 업로드 및 삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,13 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+
+    // WebClient를 사용
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/toock/backend/infra/s3/S3Config.java
+++ b/src/main/java/toock/backend/infra/s3/S3Config.java
@@ -1,0 +1,33 @@
+package toock.backend.infra.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/toock/backend/infra/s3/S3Service.java
+++ b/src/main/java/toock/backend/infra/s3/S3Service.java
@@ -1,0 +1,47 @@
+package toock.backend.infra.s3;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Util s3Util;
+
+    public String uploadImage(MultipartFile file, String folderName) {
+        String extension = s3Util.extractExtension(file);
+        String fileName = folderName + "/" + UUID.randomUUID() + extension;
+        return s3Util.uploadFile(fileName, file);
+    }
+
+    public void removeImage(String fileUrl) {
+        s3Util.deleteFile(fileUrl);
+    }
+
+
+    //음성파일 업로드를 위한 메서드들 -> 이미지랑 코드 중복이지만 나중에 음성에서 추가 작업할게 있을 수 있기 때문에 중복이더라도 메서드 생성
+
+    /**
+     * 음성 파일을 S3에 업로드합니다.
+     * @param file 음성 파일
+     * @param folderName 저장할 폴더명 (예: "audio-recordings")
+     * @return 업로드된 파일의 S3 URL
+     */
+    public String uploadAudio(MultipartFile file, String folderName) {
+        String extension = s3Util.extractExtension(file);
+        String fileName = folderName + "/" + UUID.randomUUID() + extension;
+        return s3Util.uploadFile(fileName, file);
+    }
+
+    /**
+     * S3에서 음성 파일을 삭제합니다.
+     * @param fileUrl 삭제할 파일의 S3 URL
+     */
+    public void removeAudio(String fileUrl) {
+        s3Util.deleteFile(fileUrl);
+    }
+}

--- a/src/main/java/toock/backend/infra/s3/S3Util.java
+++ b/src/main/java/toock/backend/infra/s3/S3Util.java
@@ -1,0 +1,63 @@
+package toock.backend.infra.s3;
+
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import toock.backend.infra.s3.exception.S3Exception;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3Util {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String extractExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+
+        return extension;
+    }
+
+    // 파일 업로드
+    public String uploadFile(String fileName, MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+            log.info("S3 업로드 완료...");
+        } catch (IOException e) {
+            throw new S3Exception("S3 파일 업로드에 실패했습니다.", e);
+        }
+
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    // 파일 삭제
+    public void deleteFile(String url) {
+        URI uri = URI.create(url);
+        String filePath = uri.getPath().substring(1);
+        amazonS3.deleteObject(bucket, filePath);
+    }
+
+
+
+}

--- a/src/main/java/toock/backend/infra/s3/exception/S3Exception.java
+++ b/src/main/java/toock/backend/infra/s3/exception/S3Exception.java
@@ -1,0 +1,12 @@
+package toock.backend.infra.s3.exception;
+
+public class S3Exception extends RuntimeException {
+
+    public S3Exception(String message) {
+        super(message);
+    }
+
+    public S3Exception(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,4 +3,19 @@ spring:
     name: TOOCK-backend
 
   profiles:
-    active: local  # 기본은 로컬(H2)로 실행되도록 설정
+    active: local
+    # 기본은 로컬(H2)로 실행되도록 설정
+
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      region:
+        static: ap-northeast-2
+      s3:
+        # 사용할 S3 버킷 이름을 입력하세요.
+        bucket: ${AWS_BUCKET_NAME}
+      stack:
+        # CloudFormation을 사용하지 않을 경우 false로 설정
+        auto: false

--- a/src/test/java/toock/backend/infra/s3/S3ServiceTest.java
+++ b/src/test/java/toock/backend/infra/s3/S3ServiceTest.java
@@ -1,0 +1,65 @@
+package toock.backend.infra.s3;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+    @Mock
+    private S3Util s3Util;
+
+    @InjectMocks
+    private S3Service s3Service;
+
+    @Test
+    @DisplayName("파일 업로드 성공 시 URL을 반환한다")
+    void uploadImage_success_returnsUrl() throws IOException {
+        // Given
+        String folderName = "test-audios";
+        String uniqueFilename = "test-audios/unique-id.mp3";
+        MultipartFile file = new MockMultipartFile("audioFile", "test-audio.mp3", "audio/mpeg", "content".getBytes());
+
+        // Mocking behavior
+        when(s3Util.uploadFile(anyString(), any(MultipartFile.class)))
+                .thenReturn("https://toock-test-bucket.s3.ap-northeast-2.amazonaws.com/" + uniqueFilename);
+
+        // When
+        String uploadedUrl = s3Service.uploadAudio(file, folderName);
+
+        // Then
+        assertThat(uploadedUrl).contains(folderName);
+        assertThat(uploadedUrl).contains("http");
+
+        // s3Util의 uploadFile 메서드가 정확히 한 번 호출되었는지 검증
+        verify(s3Util, times(1)).uploadFile(anyString(), any(MultipartFile.class));
+    }
+
+    @Test
+    @DisplayName("파일 삭제가 성공한다")
+    void removeImage_success() {
+        // Given
+        String fileUrl = "https://toock-test-bucket.s3.ap-northeast-2.amazonaws.com/test-audios/unique-id.mp3";
+
+        // Mocking behavior
+        doNothing().when(s3Util).deleteFile(fileUrl);
+
+        // When
+        s3Service.removeAudio(fileUrl);
+
+        // Then
+        // s3Util의 deleteFile 메서드가 정확히 한 번 호출되었는지 검증
+        verify(s3Util, times(1)).deleteFile(fileUrl);
+    }
+}


### PR DESCRIPTION
음성 파일을 AWS S3에 안전하게 저장하고 관리하는 기능을 추가합니다.

---

### **변경 사항**

* `S3Service`, `S3Util` 등 S3 연동을 위한 모듈을 `infra.s3` 패키지에 추가했습니다.
* `MultipartFile` 형태의 음성 파일을 S3에 업로드하고, URL을 반환하는 기능을 구현했습니다.
* 업로드된 파일을 S3에서 삭제하는 로직을 추가했습니다.
* `S3Service`의 비즈니스 로직을 검증하기 위해 Mocking을 활용한 단위 테스트 코드를 작성했습니다.

---

### **테스트 방법**

- `S3ServiceTest.java`를 실행하여 업로드 및 삭제 기능이 정상 동작하는 것을 확인했습니다.