### PR TITLE
feat: 면접 결과 대시보드 페이지 엔드포인트 구현

### DIFF
--- a/src/main/java/toock/backend/global/dto/CommonResponseDto.java
+++ b/src/main/java/toock/backend/global/dto/CommonResponseDto.java
@@ -1,0 +1,35 @@
+package toock.backend.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponseDto<T> {
+
+    private boolean success;
+    private String code;
+    private String message;
+    private T data;
+
+    public static <T> CommonResponseDto<T> success(T data) {
+        return CommonResponseDto.<T>builder()
+                .success(true)
+                .code("SUCCESS")
+                .message("요청에 성공하였습니다.")
+                .data(data)
+                .build();
+    }
+
+    public static <T> CommonResponseDto<T> fail(String code, String message) {
+        return CommonResponseDto.<T>builder()
+                .success(false)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/toock/backend/interview/controller/InterviewController.java
+++ b/src/main/java/toock/backend/interview/controller/InterviewController.java
@@ -9,6 +9,7 @@ import toock.backend.infra.whisper.service.WhisperService;
 import toock.backend.interview.dto.InterviewDto;
 import toock.backend.interview.dto.InterviewAnalysisResponseDto;
 import toock.backend.interview.service.InterviewService;
+import toock.backend.global.dto.CommonResponseDto;
 
 @RestController
 @RequestMapping("/interviews")
@@ -48,5 +49,11 @@ public class InterviewController {
     @PostMapping("/analyze/{interviewSessionId}")
     public ResponseEntity<InterviewAnalysisResponseDto> analyzeInterview(@PathVariable Long interviewSessionId) {
         return ResponseEntity.ok(interviewService.evaluateInterview(interviewSessionId));
+    }
+
+    @GetMapping("/results/{interviewSessionId}")
+    public ResponseEntity<CommonResponseDto<InterviewAnalysisResponseDto>> getInterviewResult(@PathVariable Long interviewSessionId) {
+        InterviewAnalysisResponseDto analysis = interviewService.getInterviewAnalysis(interviewSessionId);
+        return ResponseEntity.ok(CommonResponseDto.success(analysis));
     }
 }

--- a/src/main/java/toock/backend/interview/service/InterviewService.java
+++ b/src/main/java/toock/backend/interview/service/InterviewService.java
@@ -214,6 +214,13 @@ public class InterviewService {
         return createAnalysisResponseDto(analysis, analysis.getInterviewSession());
     }
 
+    @Transactional(readOnly = true)
+    public InterviewAnalysisResponseDto getInterviewAnalysis(Long interviewSessionId) {
+        InterviewAnalysis analysis = interviewAnalysisRepository.findByInterviewSessionId(interviewSessionId)
+                .orElseThrow(() -> new IllegalArgumentException("면접 분석을 찾을 수 없습니다. ID: " + interviewSessionId));
+        return createAnalysisResponseDto(analysis, analysis.getInterviewSession());
+    }
+
     //markdown 표시가 있을경우 제거해줌.
     private String sanitizeJsonResponse(String rawResponse) {
         String sanitized = rawResponse.trim();

--- a/src/test/java/toock/backend/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/toock/backend/interview/controller/InterviewControllerTest.java
@@ -18,9 +18,11 @@ import toock.backend.interview.service.InterviewService;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -86,5 +88,40 @@ public class InterviewControllerTest {
                 .andExpect(jsonPath("$.problemSolvingScore").value(4))
                 .andExpect(jsonPath("$.growthPotentialScore").value(3))
                 .andExpect(jsonPath("$.summary").value("좋은 요약"));
+    }
+
+    @Test
+    @DisplayName("면접 결과 조회 엔드포인트 성공")
+    void getInterviewResult_Success() throws Exception {
+        Long sessionId = 1L;
+        InterviewAnalysisResponseDto mockResponseDto = InterviewAnalysisResponseDto.builder()
+                .id(1L)
+                .interviewSessionId(sessionId)
+                .score(4)
+                .technicalExpertiseScore(5)
+                .collaborationCommunicationScore(4)
+                .problemSolvingScore(4)
+                .growthPotentialScore(3)
+                .summary("좋은 요약")
+                .build();
+
+        when(interviewService.getInterviewAnalysis(anyLong())).thenReturn(mockResponseDto);
+
+        mockMvc.perform(get("/interviews/results/{interviewSessionId}", sessionId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("요청에 성공하였습니다."))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.interviewSessionId").value(sessionId))
+                .andExpect(jsonPath("$.data.score").value(4))
+                .andExpect(jsonPath("$.data.technicalExpertiseScore").value(5))
+                .andExpect(jsonPath("$.data.collaborationCommunicationScore").value(4))
+                .andExpect(jsonPath("$.data.problemSolvingScore").value(4))
+                .andExpect(jsonPath("$.data.growthPotentialScore").value(3))
+                .andExpect(jsonPath("$.data.summary").value("좋은 요약"));
+
+        verify(interviewService).getInterviewAnalysis(sessionId);
     }
 }

--- a/src/test/java/toock/backend/interview/service/InterviewServiceTest.java
+++ b/src/test/java/toock/backend/interview/service/InterviewServiceTest.java
@@ -228,4 +228,45 @@ public class InterviewServiceTest {
         verify(objectMapper, never()).readValue(anyString(), eq(InterviewEvaluationResult.class));
         verify(interviewAnalysisRepository, never()).save(any(InterviewAnalysis.class));
     }
+
+    @Test
+    @DisplayName("면접 분석 조회 성공")
+    void getInterviewAnalysis_Success() {
+        Long sessionId = 1L;
+        InterviewAnalysis mockAnalysis = mock(InterviewAnalysis.class);
+        when(mockAnalysis.getId()).thenReturn(1L);
+        when(mockAnalysis.getInterviewSession()).thenReturn(testSession);
+        when(mockAnalysis.getScore()).thenReturn(5);
+        when(mockAnalysis.getTechnicalExpertiseScore()).thenReturn(5);
+        when(mockAnalysis.getCollaborationCommunicationScore()).thenReturn(4);
+        when(mockAnalysis.getProblemSolvingScore()).thenReturn(4);
+        when(mockAnalysis.getGrowthPotentialScore()).thenReturn(5);
+        when(mockAnalysis.getSummary()).thenReturn("최고의 요약");
+
+        when(interviewAnalysisRepository.findByInterviewSessionId(sessionId)).thenReturn(Optional.of(mockAnalysis));
+
+        InterviewAnalysisResponseDto response = interviewService.getInterviewAnalysis(sessionId);
+
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getInterviewSessionId()).isEqualTo(sessionId);
+        assertThat(response.getScore()).isEqualTo(5);
+        assertThat(response.getTechnicalExpertiseScore()).isEqualTo(5);
+        assertThat(response.getCollaborationCommunicationScore()).isEqualTo(4);
+        assertThat(response.getProblemSolvingScore()).isEqualTo(4);
+        assertThat(response.getGrowthPotentialScore()).isEqualTo(5);
+        assertThat(response.getSummary()).isEqualTo("최고의 요약");
+
+        verify(interviewAnalysisRepository).findByInterviewSessionId(sessionId);
+    }
+
+    @Test
+    @DisplayName("면접 분석 조회 실패 - 분석 결과 없음")
+    void getInterviewAnalysis_NotFound() {
+        Long sessionId = 1L;
+        when(interviewAnalysisRepository.findByInterviewSessionId(sessionId)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> interviewService.getInterviewAnalysis(sessionId));
+
+        verify(interviewAnalysisRepository).findByInterviewSessionId(sessionId);
+    }
 }


### PR DESCRIPTION
### Desc
- GET요청을 통해 DB의 인터뷰 분석 결과를 반환하도록 구현
- 프론트 요청사항에 따라 제네릭 data 필드를 가진, 공통 응답 포맷을 사용하였음
  - CommonResponseDto
- 후속으로 기존 엔드포인트도 위의 dto로 감쌀 예정