### PR TITLE
feat : 공통 응답 포맷 설정

### DIFF
--- a/src/main/java/toock/backend/global/response/ApiResponse.java
+++ b/src/main/java/toock/backend/global/response/ApiResponse.java
@@ -1,0 +1,54 @@
+package com.example.runway.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ApiResponse<T> {
+
+    @JsonProperty("success")
+    private boolean success;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("data")
+    private T data;
+
+    // 성공 (기본 200)
+    public static <T> ApiResponse<T> ok(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code("200")
+                .message("요청에 성공하였습니다.")
+                .data(data)
+                .build();
+    }
+
+    // 성공 (201/202 등 커스텀 상태)
+    public static <T> ApiResponse<T> success(int code, T data, String message) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .code(String.valueOf(code))
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    // 실패 (표준 패턴)
+    public static <T> ApiResponse<T> fail(String code, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(code)
+                .message(message)
+                .data(null)
+                .build();
+    }
+}

--- a/src/main/java/toock/backend/global/response/SuccessResponseAdvice.java
+++ b/src/main/java/toock/backend/global/response/SuccessResponseAdvice.java
@@ -1,0 +1,73 @@
+package toock.backend.global.response;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import com.example.runway.global.response.ApiResponse;
+
+@Slf4j
+@RestControllerAdvice
+public class SuccessResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response) {
+
+        // 이미 래핑된 응답은 스킵
+        if (body instanceof ApiResponse<?>) return body;
+
+
+        HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+        int statusCode = servletResponse.getStatus();
+        HttpStatus httpStatus = HttpStatus.resolve(statusCode);
+
+        //성공 코드일 경우(실패는 따로 처리)
+        if (httpStatus != null && httpStatus.is2xxSuccessful()) {
+            // 204면 본문을 쓰지 않음 (No Content)
+            if (statusCode == HttpStatus.NO_CONTENT.value()) {
+                return null;
+            }
+
+            // 상태코드가 기본값(200)으로만 들어오는 환경 대비: 메서드로 보정 (POST=201/DELETE=204/기타=200)
+            if (statusCode == 200) {
+                String method = ((ServletServerHttpRequest) request).getServletRequest().getMethod();
+                statusCode = statusProvider(method);
+                // 실 응답코드도 맞춰줌
+                servletResponse.setStatus(statusCode);
+            }
+
+
+            return ApiResponse.success(statusCode, body, "요청에 성공하였습니다.");
+        }
+
+        // 비-2xx는 이 Advice에서 건드리지 않고 ExceptionHandler에서 처리하도록 둠
+        return body;
+    }
+
+    private int statusProvider(String method) {
+        return switch (method) {
+            case "POST" -> 201;
+            case "DELETE" -> 204;
+            default -> 200;
+        };
+    }
+}

--- a/src/main/java/toock/backend/interview/controller/InterviewController.java
+++ b/src/main/java/toock/backend/interview/controller/InterviewController.java
@@ -19,12 +19,12 @@ public class InterviewController {
     private final WhisperService whisperService;
 
     @PostMapping("/start")
-    public ResponseEntity<InterviewDto.StartResponse> startInterview(@RequestBody InterviewDto.StartRequest request) {
-        return ResponseEntity.ok(interviewService.startInterview(request));
+    public InterviewDto.StartResponse startInterview(@RequestBody InterviewDto.StartRequest request) {
+        return interviewService.startInterview(request);
     }
 
     @PostMapping("/next")
-    public ResponseEntity<InterviewDto.NextResponse> nextQuestion(
+    public InterviewDto.NextResponse nextQuestion(
             @RequestParam("interviewSessionId") Long interviewSessionId,
             @RequestParam("audioFile") MultipartFile audioFile) {
 
@@ -41,6 +41,6 @@ public class InterviewController {
         request.setS3Url(s3Url);
 
         // 4. 면접 로직을 처리하고 다음 질문을 받아 응답합니다.
-        return ResponseEntity.ok(interviewService.nextQuestion(request));
+        return interviewService.nextQuestion(request);
     }
 }


### PR DESCRIPTION
## 응답 포맷

성공 응답 모두 응답을 가로채서 자동으로 가공할 수 있도록 설정해 두었음

코드 작성할 때 그냥 `ResponseEntity<T>` 사용해서 개발

Controller에서 DTO를 반환하면, 자동으로 형식에 맞게 가공해서 변환하게 하였음

기존에 ResponseEntity.ok 형식으로 return하였다면

`InterviewController` 처럼 DTO로 반환하게 변경해서 사용하면 됨