### PR TITLE
Feat : 대시보드 API 구현

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -207,7 +207,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 # Collect all arguments for the java command:
 #   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 #     and any embedded shellness will be escaped.
-#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#   * For example: A member cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
 
 set -- \

--- a/src/main/java/toock/backend/auth/controller/AuthController.java
+++ b/src/main/java/toock/backend/auth/controller/AuthController.java
@@ -59,7 +59,7 @@ public class AuthController {
     public ResponseEntity<String> getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {
-            return ResponseEntity.ok("현재 인증된 사용자: " + authentication.getName());
+            return ResponseEntity.ok("현재 인증된 사용자 ID: " + authentication.getName());
         }
         return ResponseEntity.ok("인증되지 않은 사용자");
     }

--- a/src/main/java/toock/backend/auth/controller/AuthController.java
+++ b/src/main/java/toock/backend/auth/controller/AuthController.java
@@ -59,7 +59,7 @@ public class AuthController {
     public ResponseEntity<String> getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {
-            return ResponseEntity.ok("현재 인증된 사용자: " + authentication.getName());
+            return ResponseEntity.ok("현재 인증된 사용자ID: " + authentication.getName());
         }
         return ResponseEntity.ok("인증되지 않은 사용자");
     }

--- a/src/main/java/toock/backend/auth/controller/AuthController.java
+++ b/src/main/java/toock/backend/auth/controller/AuthController.java
@@ -59,7 +59,7 @@ public class AuthController {
     public ResponseEntity<String> getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated()) {
-            return ResponseEntity.ok("현재 인증된 사용자 ID: " + authentication.getName());
+            return ResponseEntity.ok("현재 인증된 사용자: " + authentication.getName());
         }
         return ResponseEntity.ok("인증되지 않은 사용자");
     }

--- a/src/main/java/toock/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/toock/backend/auth/filter/JwtAuthenticationFilter.java
@@ -35,10 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long memberId = jwtUtil.extractMemberId(token);
                 
                 UsernamePasswordAuthenticationToken authentication = 
-                    new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+                    new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
                 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("JWT 인증 성공: ID :{}, email :{}", memberId,email);
+                log.debug("JWT 인증 성공: {}", email);
             } catch (Exception e) {
                 log.error("JWT 토큰 처리 중 오류 발생", e);
             }

--- a/src/main/java/toock/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/toock/backend/auth/filter/JwtAuthenticationFilter.java
@@ -35,10 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long memberId = jwtUtil.extractMemberId(token);
                 
                 UsernamePasswordAuthenticationToken authentication = 
-                    new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+                    new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
                 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("JWT 인증 성공: {}", email);
+                log.debug("JWT 인증 성공: ID :{}, email :{}", memberId,email);
             } catch (Exception e) {
                 log.error("JWT 토큰 처리 중 오류 발생", e);
             }

--- a/src/main/java/toock/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/toock/backend/auth/filter/JwtAuthenticationFilter.java
@@ -35,10 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long memberId = jwtUtil.extractMemberId(token);
                 
                 UsernamePasswordAuthenticationToken authentication = 
-                    new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+                    new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
                 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-                log.debug("JWT 인증 성공: {}", email);
+                log.debug("JWT 인증 성공 ID: {}", memberId);
             } catch (Exception e) {
                 log.error("JWT 토큰 처리 중 오류 발생", e);
             }

--- a/src/main/java/toock/backend/auth/service/AuthService.java
+++ b/src/main/java/toock/backend/auth/service/AuthService.java
@@ -10,12 +10,11 @@ import org.springframework.stereotype.Service;
 import toock.backend.auth.dto.GoogleUserInfo;
 import toock.backend.auth.dto.LoginResponseDto;
 import toock.backend.auth.util.JwtUtil;
-import toock.backend.user.domain.Field;
-import toock.backend.user.domain.Member;
-import toock.backend.user.repository.MemberRepository;
+import toock.backend.member.domain.Field;
+import toock.backend.member.domain.Member;
+import toock.backend.member.repository.MemberRepository;
 
 import java.util.Map;
-import java.util.UUID;
 
 @Slf4j
 @Service

--- a/src/main/java/toock/backend/interview/controller/InterviewController.java
+++ b/src/main/java/toock/backend/interview/controller/InterviewController.java
@@ -2,6 +2,7 @@ package toock.backend.interview.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import toock.backend.infra.s3.S3Service;
@@ -21,14 +22,16 @@ public class InterviewController {
     private final WhisperService whisperService;
 
     @PostMapping("/start")
-    public ResponseEntity<InterviewDto.StartResponse> startInterview(@RequestBody InterviewDto.StartRequest request) {
-        return ResponseEntity.ok(interviewService.startInterview(request));
+    public ResponseEntity<InterviewDto.StartResponse> startInterview(@RequestBody InterviewDto.StartRequest request, @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(interviewService.startInterview(request,memberId));
     }
 
     @PostMapping("/next")
     public ResponseEntity<InterviewDto.NextResponse> nextQuestion(
             @RequestParam("interviewSessionId") Long interviewSessionId,
-            @RequestParam("audioFile") MultipartFile audioFile) {
+            @RequestParam("audioFile") MultipartFile audioFile,
+            @AuthenticationPrincipal Long memberId
+            ) {
 
         // 1. 음성 파일을 S3에 업로드하고 URL을 받음.
         String s3Url = s3Service.uploadAudio(audioFile, "interview-audio");
@@ -43,7 +46,7 @@ public class InterviewController {
         request.setS3Url(s3Url);
 
         // 4. 면접 로직을 처리하고 다음 질문을 받아 응답합니다.
-        return ResponseEntity.ok(interviewService.nextQuestion(request));
+        return ResponseEntity.ok(interviewService.nextQuestion(request,memberId));
     }
 
     @PostMapping("/analyze/{interviewSessionId}")

--- a/src/main/java/toock/backend/interview/domain/InterviewSession.java
+++ b/src/main/java/toock/backend/interview/domain/InterviewSession.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import toock.backend.company.domain.Company;
-import toock.backend.user.domain.Field;
-import toock.backend.user.domain.Member;
+import toock.backend.member.domain.Member;
 
 import java.time.OffsetDateTime;
 

--- a/src/main/java/toock/backend/interview/dto/InterviewDto.java
+++ b/src/main/java/toock/backend/interview/dto/InterviewDto.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import toock.backend.interview.domain.InterviewFieldCategory;
-import toock.backend.user.domain.Field; // User 도메인의 Field Enum 사용
 
 public class InterviewDto {
 

--- a/src/main/java/toock/backend/interview/dto/InterviewDto.java
+++ b/src/main/java/toock/backend/interview/dto/InterviewDto.java
@@ -11,7 +11,6 @@ public class InterviewDto {
     // 면접 시작 요청 DTO
     @Getter @Setter @NoArgsConstructor
     public static class StartRequest {
-        private Long memberId;
         private String companyName;
         private InterviewFieldCategory field; // User의 Field가 아닌 InterviewFieldCategory 사용
     }

--- a/src/main/java/toock/backend/interview/repository/InterviewAnalysisRepository.java
+++ b/src/main/java/toock/backend/interview/repository/InterviewAnalysisRepository.java
@@ -1,12 +1,34 @@
 package toock.backend.interview.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import toock.backend.interview.domain.InterviewAnalysis;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface InterviewAnalysisRepository extends JpaRepository<InterviewAnalysis, Long> {
     Optional<InterviewAnalysis> findByInterviewSessionId(Long interviewSessionId);
+
+    List<InterviewAnalysis> findByInterviewSessionIdIn(List<Long> interviewSessionIds);
+
+    /**
+     * 특정 사용자의 특정 기간 내에 시작된 면접 중 분석이 완료된 면접의 수를 계산합니다.
+     * @param memberId 사용자의 ID
+     * @param startOfWeek 주의 시작 시간
+     * @param endOfWeek 주의 종료 시간
+     * @return 분석 완료된 면접 수
+     */
+    @Query("SELECT COUNT(ia) FROM InterviewAnalysis ia " +
+           "JOIN ia.interviewSession s " +
+           "WHERE s.member.id = :memberId " +
+           "AND s.startedAt BETWEEN :startOfWeek AND :endOfWeek")
+    long countAnalyzedInterviewsByMemberAndDateRange(
+            @Param("memberId") Long memberId,
+            @Param("startOfWeek") OffsetDateTime startOfWeek,
+            @Param("endOfWeek") OffsetDateTime endOfWeek);
 }

--- a/src/main/java/toock/backend/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/toock/backend/interview/repository/InterviewSessionRepository.java
@@ -3,5 +3,11 @@ package toock.backend.interview.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import toock.backend.interview.domain.InterviewSession;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+
 public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long> {
+    List<InterviewSession> findByMemberId(Long memberId);
+
+    long countByMemberIdAndStartedAtBetween(Long memberId, OffsetDateTime start, OffsetDateTime end);
 }

--- a/src/main/java/toock/backend/interview/service/InterviewService.java
+++ b/src/main/java/toock/backend/interview/service/InterviewService.java
@@ -56,9 +56,9 @@ public class InterviewService {
 
 
     @Transactional
-    public InterviewDto.StartResponse startInterview(InterviewDto.StartRequest request) {
-        Member member = memberRepository.findById(request.getMemberId())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + request.getMemberId()));
+    public InterviewDto.StartResponse startInterview(InterviewDto.StartRequest request,Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " +memberId));
         Company company = companyRepository.findByName(request.getCompanyName())
                 .orElseThrow(() -> new IllegalArgumentException("회사를 찾을 수 없습니다. 이름: " + request.getCompanyName()));
 
@@ -115,9 +115,14 @@ public class InterviewService {
     }
 
     @Transactional
-    public InterviewDto.NextResponse nextQuestion(InterviewDto.NextRequest request) {
+    public InterviewDto.NextResponse nextQuestion(InterviewDto.NextRequest request,Long memberId) {
         InterviewSession session = interviewSessionRepository.findById(request.getInterviewSessionId())
                 .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다. ID: " + request.getInterviewSessionId()));
+
+        if (!session.getMember().getId().equals(memberId)) {
+            // 다른 사람의 면접에 접근하려고 하면 에러 발생
+            throw new SecurityException("해당 면접에 접근할 권한이 없습니다.");
+        }
 
         List<InterviewQA> allQAs = interviewQARepository.findByInterviewSession_IdOrderByQuestionOrderAscFollowUpOrderAsc(session.getId());
 

--- a/src/main/java/toock/backend/interview/service/InterviewService.java
+++ b/src/main/java/toock/backend/interview/service/InterviewService.java
@@ -12,7 +12,6 @@ import toock.backend.company.domain.Company;
 import toock.backend.company.domain.CompanyReview;
 import toock.backend.company.repository.CompanyRepository;
 import toock.backend.company.repository.CompanyReviewRepository;
-import toock.backend.interview.domain.InterviewFieldCategory;
 import toock.backend.interview.domain.InterviewQA;
 import toock.backend.interview.domain.InterviewAnalysis;
 import toock.backend.interview.domain.InterviewSession;
@@ -22,17 +21,14 @@ import toock.backend.interview.dto.InterviewEvaluationResult;
 import toock.backend.interview.repository.InterviewQARepository;
 import toock.backend.interview.repository.InterviewSessionRepository;
 import toock.backend.interview.repository.InterviewAnalysisRepository;
-import toock.backend.user.domain.Member;
-import toock.backend.user.repository.MemberRepository;
+import toock.backend.member.domain.Member;
+import toock.backend.member.repository.MemberRepository;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static toock.backend.interview.domain.InterviewFieldCategory.*;
 
 @Slf4j
 @Service

--- a/src/main/java/toock/backend/member/controller/MemberController.java
+++ b/src/main/java/toock/backend/member/controller/MemberController.java
@@ -1,0 +1,36 @@
+package toock.backend.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import toock.backend.global.dto.CommonResponseDto;
+import toock.backend.member.dto.MemberNicknameResponseDto;
+import toock.backend.member.dto.MemberStatisticsResponseDto;
+import toock.backend.member.service.MemberService;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/nickname")
+    public ResponseEntity<CommonResponseDto<MemberNicknameResponseDto>> getMemberNickname(
+            @AuthenticationPrincipal Long memberId) {
+        MemberNicknameResponseDto response = memberService.getMemberNickname(memberId);
+        return ResponseEntity.ok(CommonResponseDto.success(response));
+    }
+
+    @GetMapping("/statistics")
+    public ResponseEntity<CommonResponseDto<MemberStatisticsResponseDto>> getUserStatistics(
+            @AuthenticationPrincipal Long memberId) {
+        MemberStatisticsResponseDto statistics = memberService.getUserStatistics(memberId);
+        return ResponseEntity.ok(CommonResponseDto.success(statistics));
+    }
+}
+
+

--- a/src/main/java/toock/backend/member/domain/Field.java
+++ b/src/main/java/toock/backend/member/domain/Field.java
@@ -1,4 +1,4 @@
-package toock.backend.user.domain;
+package toock.backend.member.domain;
 
 public enum Field {
     DEFAULT,

--- a/src/main/java/toock/backend/member/domain/Member.java
+++ b/src/main/java/toock/backend/member/domain/Member.java
@@ -1,4 +1,4 @@
-package toock.backend.user.domain;
+package toock.backend.member.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/toock/backend/member/domain/Status.java
+++ b/src/main/java/toock/backend/member/domain/Status.java
@@ -1,4 +1,4 @@
-package toock.backend.user.domain;
+package toock.backend.member.domain;
 
 public enum Status {
     ACTIVATED,

--- a/src/main/java/toock/backend/member/dto/MemberNicknameResponseDto.java
+++ b/src/main/java/toock/backend/member/dto/MemberNicknameResponseDto.java
@@ -1,0 +1,10 @@
+package toock.backend.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberNicknameResponseDto {
+    private String nickname;
+}

--- a/src/main/java/toock/backend/member/dto/MemberStatisticsResponseDto.java
+++ b/src/main/java/toock/backend/member/dto/MemberStatisticsResponseDto.java
@@ -1,0 +1,13 @@
+package toock.backend.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberStatisticsResponseDto {
+    private long totalInterviews;
+    private double averageScore;
+    private Integer bestScore;
+    private long interviewsThisWeek;
+}

--- a/src/main/java/toock/backend/member/repository/MemberRepository.java
+++ b/src/main/java/toock/backend/member/repository/MemberRepository.java
@@ -1,10 +1,10 @@
-package toock.backend.user.repository;
+package toock.backend.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 import org.springframework.stereotype.Repository;
-import toock.backend.user.domain.Member;
+import toock.backend.member.domain.Member;
 
 import java.util.Optional;
 

--- a/src/main/java/toock/backend/member/service/MemberService.java
+++ b/src/main/java/toock/backend/member/service/MemberService.java
@@ -1,0 +1,78 @@
+package toock.backend.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import toock.backend.interview.domain.InterviewAnalysis;
+import toock.backend.interview.domain.InterviewSession;
+import toock.backend.interview.repository.InterviewAnalysisRepository;
+import toock.backend.interview.repository.InterviewSessionRepository;
+import toock.backend.member.domain.Member;
+import toock.backend.member.dto.MemberNicknameResponseDto;
+import toock.backend.member.dto.MemberStatisticsResponseDto;
+import toock.backend.member.repository.MemberRepository;
+
+import java.time.DayOfWeek;
+import java.time.OffsetDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewAnalysisRepository interviewAnalysisRepository;
+
+    @Transactional(readOnly = true)
+    public MemberNicknameResponseDto getMemberNickname(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. ID: " + memberId));
+
+        return MemberNicknameResponseDto.builder()
+                .nickname(member.getName()) // Member 엔티티의 name 필드를 반환
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public MemberStatisticsResponseDto getUserStatistics(Long memberId) {
+        // 1. 사용자의 모든 면접 세션 ID 조회
+        List<Long> sessionIds = interviewSessionRepository.findByMemberId(memberId)
+                .stream()
+                .map(InterviewSession::getId)
+                .collect(Collectors.toList());
+
+        // 2. 완료된 면접에 대한 모든 분석 결과 조회
+        List<InterviewAnalysis> analyses = interviewAnalysisRepository.findByInterviewSessionIdIn(sessionIds);
+
+
+        // 3. 통계 계산
+        long totalInterviews = analyses.size();
+        double averageScore = analyses.stream()
+                .mapToInt(InterviewAnalysis::getScore)
+                .average()
+                .orElse(0.0);
+        Integer bestScore = analyses.stream()
+                .mapToInt(InterviewAnalysis::getScore)
+                .max()
+                .orElse(0);
+
+        // 4. 이번 주에 '분석까지 완료된' 면접 횟수 계산 (월요일 시작 ~ 일요일 끝)
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime startOfWeek = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).withHour(0).withMinute(0).withSecond(0);
+        OffsetDateTime endOfWeek = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).withHour(23).withMinute(59).withSecond(59);
+
+        long interviewsThisWeek = interviewAnalysisRepository.countAnalyzedInterviewsByMemberAndDateRange(memberId, startOfWeek, endOfWeek);
+
+        return MemberStatisticsResponseDto.builder()
+                .totalInterviews(totalInterviews)
+                .averageScore(averageScore)
+                .bestScore(bestScore)
+                .interviewsThisWeek(interviewsThisWeek)
+                .build();
+    }
+}

--- a/src/test/java/toock/backend/interview/service/InterviewServiceTest.java
+++ b/src/test/java/toock/backend/interview/service/InterviewServiceTest.java
@@ -16,7 +16,7 @@ import toock.backend.interview.dto.InterviewEvaluationResult;
 import toock.backend.interview.repository.InterviewAnalysisRepository;
 import toock.backend.interview.repository.InterviewQARepository;
 import toock.backend.interview.repository.InterviewSessionRepository;
-import toock.backend.user.repository.MemberRepository;
+import toock.backend.member.repository.MemberRepository;
 import toock.backend.company.repository.CompanyRepository;
 import toock.backend.company.repository.CompanyReviewRepository;
 


### PR DESCRIPTION
<img width="1259" height="332" alt="image" src="https://github.com/user-attachments/assets/fe01e486-7afa-478a-a435-19770f934d41" />

화면에 맞는 response 출력

<img width="648" height="662" alt="image" src="https://github.com/user-attachments/assets/7dcf53c3-e54c-43ee-9409-7175c7146832" />


닉네임만 따로 조회할 수 있는
/users/nickname
API 생성